### PR TITLE
Update native unit of measurement

### DIFF
--- a/custom_components/monzo/sensor.py
+++ b/custom_components/monzo/sensor.py
@@ -40,7 +40,7 @@ ACC_SENSORS = (
         name="Balance",
         value=lambda data: data["balance"]["balance"] / 100,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="£",
+        native_unit_of_measurement="GBP",
         suggested_display_precision=2,
     ),
     MonzoSensorEntityDescription(
@@ -48,7 +48,7 @@ ACC_SENSORS = (
         name="Total Balance",
         value=lambda data: data["balance"]["total_balance"] / 100,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="£",
+        native_unit_of_measurement="GBP",
         suggested_display_precision=2,
     ),
 )
@@ -59,7 +59,7 @@ POT_SENSORS = (
         name="Balance",
         value=lambda data: data["balance"] / 100,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="£",
+        native_unit_of_measurement="GBP",
         suggested_display_precision=2,
     ),
 )


### PR DESCRIPTION
Might be the opposite of what you might expect, but specifying "£" in the native unit of measurement causes the symbol to appear at the end of the value. Home Assistant already has logic built in to convert currency codes to symbols so updating this to the currency will make sure the symbol is in the right place.