### PR TITLE
Improve logging when update fails with InvalidMonzoAPIResponse

### DIFF
--- a/custom_components/monzo/coordinator.py
+++ b/custom_components/monzo/coordinator.py
@@ -3,13 +3,14 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from pprint import pformat
 from typing import Any
 
-from monzopy import AuthorisationExpiredError
+from monzopy import AuthorisationExpiredError, InvalidMonzoAPIResponseError
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import AuthenticatedMonzoAPI
 from .const import DOMAIN
@@ -45,5 +46,16 @@ class MonzoCoordinator(DataUpdateCoordinator[MonzoSensorData]):
             pots = await self.api.user_account.pots()
         except AuthorisationExpiredError as err:
             raise ConfigEntryAuthFailed from err
+        except InvalidMonzoAPIResponseError as err:
+            message = "Invalid Monzo API response."
+            if err.missing_key:
+                _LOGGER.debug(
+                    "%s\nMissing key: %s\nResponse:\n%s",
+                    message,
+                    err.missing_key,
+                    pformat(err.response),
+                )
+                message += " Enabling debug logging for details."
+            raise UpdateFailed(message) from err
 
         return MonzoSensorData(accounts, pots)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from importlib.metadata import version
 from packaging.version import Version
 from freezegun.api import FrozenDateTimeFactory
+from monzopy import InvalidMonzoAPIResponseError
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -128,14 +129,21 @@ async def test_update_failed(
     monzo: AsyncMock,
     polling_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test all entities."""
     await setup_integration(hass, polling_config_entry)
 
-    monzo.user_account.accounts.side_effect = Exception
+    monzo.user_account.accounts.side_effect = InvalidMonzoAPIResponseError(
+        {"acc_id": None}, "account_id"
+    )
     freezer.tick(timedelta(minutes=10))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    assert "Invalid Monzo API response." in caplog.text
+    assert "account_id" in caplog.text
+    assert "acc_id" in caplog.text
 
     entity_id = await async_get_entity_id(
         hass, TEST_ACCOUNTS[0]["id"], ACCOUNT_SENSORS[0]


### PR DESCRIPTION
When a sensor update fails with an InvalidMonzoAPIResponseError, raise an UpdateFailed error in Home Assistant so this can be displayed properly.

Additionally, add the error response to the logs. If debug logging is enabled for the integration, users should be able to see what Monzo is sending that's causing the failure, which should greatly aid in helping users with issues I can't recreate.